### PR TITLE
lib: add iterator over LPM rules

### DIFF
--- a/lib/librte_lpm/rte_lpm.h
+++ b/lib/librte_lpm/rte_lpm.h
@@ -188,6 +188,61 @@ struct rte_lpm {
 	struct rte_lpm_rule *rules_tbl; /**< LPM rules. */
 };
 
+/** LPM iterator state structure. */
+struct rte_lpm_iterator_state {
+	uint32_t dmask;
+	uint32_t ip_masked;
+	uint8_t  depth;
+	uint32_t next;
+	const struct rte_lpm *lpm;
+};
+
+/**
+ * Initialize the lpm iterator state.
+ *
+ * @param lpm
+ *   LPM object handle
+ * @param ip
+ *   IP of the rule to be searched
+ * @param depth
+ *   Initial depth of the rule to be searched.
+ *   Pass zero to enumerate the whole LPM table.
+ * @param state
+ *   Pointer to the iterator state
+ * @return
+ *   0 on successfully initialize the state variable, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ */
+int
+rte_lpm_iterator_state_init(const struct rte_lpm *lpm, uint32_t ip,
+	uint8_t depth, struct rte_lpm_iterator_state *state);
+
+/**
+ * An iterator over its rule entries.
+ * The iterator should require a prefix as a parameter
+ * and should list all entries as long as the given prefix (or longer).
+ *
+ * @param state
+ *   Pointer to the LPM rule iterator state
+ * @param rule
+ *   Pointer to the next rule entry
+ * @return
+ *   0 on successfully searching the next rule entry, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ *   - ENOENT - no rule entries found
+ */
+int
+rte_lpm_rule_iterate(struct rte_lpm_iterator_state *state,
+	const struct rte_lpm_rule **rule);
+int
+rte_lpm_rule_iterate_v20(struct rte_lpm_iterator_state *state,
+	const struct rte_lpm_rule **rule);
+int
+rte_lpm_rule_iterate_v1604(struct rte_lpm_iterator_state *state,
+	const struct rte_lpm_rule **rule);
+
 /**
  * Create an LPM object.
  *

--- a/lib/librte_lpm/rte_lpm6.c
+++ b/lib/librte_lpm/rte_lpm6.c
@@ -63,13 +63,6 @@ struct rte_lpm6_tbl_entry {
 	uint32_t ext_entry :1;   /**< External entry. */
 };
 
-/** Rules tbl entry structure. */
-struct rte_lpm6_rule {
-	uint8_t ip[RTE_LPM6_IPV6_ADDR_SIZE]; /**< Rule IP address. */
-	uint32_t next_hop; /**< Rule next hop. */
-	uint8_t depth; /**< Rule depth. */
-};
-
 /** LPM6 structure. */
 struct rte_lpm6 {
 	/* LPM metadata. */
@@ -109,6 +102,81 @@ mask_ip(uint8_t *ip, uint8_t depth)
 			}
 			part_depth -= BYTE_SIZE;
 		}
+}
+
+int
+rte_lpm6_iterator_state_init(const struct rte_lpm6 *lpm, uint8_t *ip,
+	uint8_t depth, struct rte_lpm6_iterator_state *state)
+{
+	if (lpm == NULL || depth > RTE_LPM6_MAX_DEPTH || state == NULL)
+		return -EINVAL;
+
+	if (ip == NULL)
+		memset(state->ip_masked, 0, sizeof(state->ip_masked));
+	else {
+		rte_memcpy(state->ip_masked, ip, sizeof(state->ip_masked));
+		mask_ip(state->ip_masked, depth);
+	}
+
+	state->depth = depth;
+	state->next = 0;
+	state->lpm = lpm;
+
+	return 0;
+}
+
+/*
+ * An iterator over its rule entries.
+ */
+int
+rte_lpm6_rule_iterate(struct rte_lpm6_iterator_state *state,
+	const struct rte_lpm6_rule **rule)
+{
+	uint32_t index;
+
+	/* Check user arguments. */
+	if (state == NULL || rule == NULL) {
+		if (rule != NULL)
+			*rule = NULL;
+
+		return -EINVAL;
+	}
+
+	if (state->next >= state->lpm->used_rules) {
+		*rule = NULL;
+		return -ENOENT;
+	}
+
+	index = state->next;
+
+	/* Scan used rules to find rules. */
+	while (index < state->lpm->used_rules) {
+		uint8_t rule_ip_masked[RTE_LPM6_IPV6_ADDR_SIZE];
+
+		if (state->lpm->rules_tbl[index].depth < state->depth) {
+			index++;
+			continue;
+		}
+
+		rte_memcpy(rule_ip_masked, state->lpm->rules_tbl[index].ip,
+			RTE_LPM6_IPV6_ADDR_SIZE);
+		mask_ip(rule_ip_masked, state->depth);
+
+		/* If rule is found return the rule index. */
+		if ((memcmp(state->ip_masked, rule_ip_masked,
+				RTE_LPM6_IPV6_ADDR_SIZE) == 0)) {
+			state->next = index + 1;
+			*rule = (const struct rte_lpm6_rule *)
+				&state->lpm->rules_tbl[index];
+			return 0;
+		}
+
+		index++;
+	}
+
+	state->next = index;
+	*rule = NULL;
+	return -ENOENT;
 }
 
 /*

--- a/lib/librte_lpm/rte_lpm6.h
+++ b/lib/librte_lpm/rte_lpm6.h
@@ -22,6 +22,13 @@ extern "C" {
 /** Max number of characters in LPM name. */
 #define RTE_LPM6_NAMESIZE                 32
 
+/** Rules tbl entry structure. */
+struct rte_lpm6_rule {
+	uint8_t ip[RTE_LPM6_IPV6_ADDR_SIZE]; /**< Rule IP address. */
+	uint8_t next_hop; /**< Rule next hop. */
+	uint8_t depth; /**< Rule depth. */
+};
+
 /** LPM structure. */
 struct rte_lpm6;
 
@@ -31,6 +38,55 @@ struct rte_lpm6_config {
 	uint32_t number_tbl8s;   /**< Number of tbl8s to allocate. */
 	int flags;               /**< This field is currently unused. */
 };
+
+/** LPM6 iterator state structure. */
+struct rte_lpm6_iterator_state {
+	uint8_t  ip_masked[RTE_LPM6_IPV6_ADDR_SIZE];
+	uint8_t  depth;
+	uint32_t next;
+	const struct rte_lpm6 *lpm;
+};
+
+/**
+ * Initialize the lpm iterator state.
+ *
+ * @param lpm
+ *   LPM object handle
+ * @param ip
+ *   IP of the rule to be searched
+ *   ip == NULL behaves as having passed an all-zero IPv6 address
+ * @param depth
+ *   Initial depth of the rule to be searched.
+ *   Pass zero to enumerate the whole LPM table.
+ * @param state
+ *   Pointer to the iterator state
+ * @return
+ *   0 on successfully initialize the state variable, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ */
+int
+rte_lpm6_iterator_state_init(const struct rte_lpm6 *lpm, uint8_t *ip,
+	uint8_t depth, struct rte_lpm6_iterator_state *state);
+
+/**
+ * An iterator over its rule entries.
+ * The iterator should require a prefix as a parameter
+ * and should list all entries as long as the given prefix (or longer).
+ *
+ * @param state
+ *   Pointer to the LPM rule iterator state
+ * @param rule
+ *   Pointer to the next rule entry
+ * @return
+ *   0 on successfully searching the next rule entry, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ *   - ENOENT - no rule entries found
+ */
+int
+rte_lpm6_rule_iterate(struct rte_lpm6_iterator_state *state,
+	const struct rte_lpm6_rule **rule);
 
 /**
  * Create an LPM object.


### PR DESCRIPTION
Add an iterator over the LPM rule entries.
The iterator requires a prefix as a parameter and
lists all entries as long as the given prefix (or longer).

Signed-off-by: Qiaobin Fu <qiaobinf@bu.edu>
Reviewed-by: Cody Doucette <doucette@bu.edu>
Reviewed-by: Michel Machado <michel@digirati.com.br>