### PR TITLE
hash table: add an iterator over conflicting entries

### DIFF
--- a/lib/librte_hash/rte_cuckoo_hash.h
+++ b/lib/librte_hash/rte_cuckoo_hash.h
@@ -211,4 +211,16 @@ struct queue_node {
 	int prev_slot;               /* Parent(slot) in search path */
 };
 
+struct rte_hash_iterator_priv {
+	uint32_t next;
+	uint32_t total_entries_main;
+	uint32_t total_entries;
+};
+
+struct rte_hash_iterator_conflict_entries_priv {
+	uint32_t vnext;
+	struct rte_hash_bucket *sec_bkt;
+	struct rte_hash_bucket *cur_bkt;
+};
+
 #endif

--- a/lib/librte_hash/rte_hash.h
+++ b/lib/librte_hash/rte_hash.h
@@ -56,6 +56,9 @@ extern "C" {
  */
 #define RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY_LF 0x20
 
+/** Size of the hash table iterator state structure */
+#define RTE_HASH_ITERATOR_STATE_SIZE 64
+
 /**
  * The type of hash value of a key.
  * It should be a value of at least 32bit with fully random pattern.
@@ -85,6 +88,16 @@ struct rte_hash_parameters {
 
 /** @internal A hash table structure. */
 struct rte_hash;
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * @internal A hash table iterator state structure.
+ */
+struct rte_hash_iterator_state {
+	uint8_t space[RTE_HASH_ITERATOR_STATE_SIZE];
+} __rte_cache_aligned;
 
 /**
  * Create a new hash table.
@@ -524,6 +537,9 @@ rte_hash_lookup_bulk(const struct rte_hash *h, const void **keys,
 		      uint32_t num_keys, int32_t *positions);
 
 /**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
  * Iterate through the hash table, returning key-value pairs.
  *
  * @param h
@@ -534,16 +550,96 @@ rte_hash_lookup_bulk(const struct rte_hash *h, const void **keys,
  * @param data
  *   Output containing the data associated with key.
  *   Returns NULL if data was not stored.
- * @param next
- *   Pointer to iterator. Should be 0 to start iterating the hash table.
- *   Iterator is incremented after each call of this function.
+ * @param state
+ *   Pointer to the iterator state.
  * @return
  *   Position where key was stored, if successful.
  *   - -EINVAL if the parameters are invalid.
  *   - -ENOENT if end of the hash table.
  */
 int32_t
-rte_hash_iterate(const struct rte_hash *h, const void **key, void **data, uint32_t *next);
+rte_hash_iterate(const struct rte_hash *h,
+	const void **key,
+	void **data,
+	struct rte_hash_iterator_state *state);
+
+int32_t
+rte_hash_iterate_v1808(const struct rte_hash *h,
+	const void **key,
+	void **data,
+	uint32_t *next);
+
+int32_t
+rte_hash_iterate_v1811(const struct rte_hash *h,
+	const void **key,
+	void **data,
+	struct rte_hash_iterator_state *state);
+BIND_DEFAULT_SYMBOL(rte_hash_iterate, _v1811, 18.11);
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * Get the current iterator position.
+ *
+ * @param state
+ *   Pointer to the iterator state.
+ * @return
+ *   The current iterator position, if successful.
+ *   - -EINVAL if the parameters are invalid.
+ */
+uint32_t __rte_experimental
+rte_hash_iterator_get_iter(const struct rte_hash_iterator_state *state);
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * Set the current iterator position.
+ *
+ * @param h
+ *   Hash table that the iterator relates.
+ * @param next
+ *   The iterator position to be set.
+ * @param state
+ *   Pointer to the iterator state.
+ * @return
+ *   - -EINVAL if the parameters are invalid, otherwise 0.
+ */
+uint32_t __rte_experimental
+rte_hash_iterator_set_iter(const struct rte_hash *h,
+	uint32_t next,
+	struct rte_hash_iterator_state *state);
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * Iterate over entries that conflict with a given hash.
+ *
+ * @param h
+ *   Hash table to iterate.
+ * @param key
+ *   Output containing the key at where the iterator is currently pointing.
+ * @param data
+ *   Output containing the data associated with key.
+ *   Returns NULL if data was not stored.
+ * @param sig
+ *   Precomputed hash value for the conflict entry.
+ * @param state
+ *   Pointer to the iterator state.
+ * @return
+ *   Position where key was stored, if successful.
+ *   - -EINVAL if the parameters are invalid.
+ *   - -ENOENT if there is no more conflicting entries.
+ */
+int32_t __rte_experimental
+rte_hash_iterate_conflict_entries_with_hash(struct rte_hash *h,
+	const void **key,
+	void **data,
+	hash_sig_t sig,
+	struct rte_hash_iterator_state *state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/librte_hash/rte_hash_version.map
+++ b/lib/librte_hash/rte_hash_version.map
@@ -54,9 +54,19 @@ DPDK_18.08 {
 
 } DPDK_16.07;
 
+DPDK_18.11 {
+	global:
+
+	rte_hash_iterate;
+
+} DPDK_18.08;
+
 EXPERIMENTAL {
 	global:
 
 	rte_hash_free_key_with_position;
+	rte_hash_iterator_get_iter;
+	rte_hash_iterator_set_iter;
+	rte_hash_iterate_conflict_entries_with_hash;
 
 };

--- a/lib/librte_lpm/rte_lpm6.c
+++ b/lib/librte_lpm/rte_lpm6.c
@@ -231,10 +231,12 @@ rebuild_lpm(struct rte_lpm6 *lpm)
 {
 	uint64_t next_hop;
 	struct rte_lpm6_rule_key *rule_key;
-	uint32_t iter = 0;
+	struct rte_hash_iterator_state state;
+
+	memset(&state, 0, sizeof(state));
 
 	while (rte_hash_iterate(lpm->rules_tbl, (void *) &rule_key,
-			(void **) &next_hop, &iter) >= 0)
+			(void **) &next_hop, &state) >= 0)
 		rte_lpm6_add(lpm, rule_key->ip, rule_key->depth,
 			(uint32_t) next_hop);
 }

--- a/test/test/test_hash.c
+++ b/test/test/test_hash.c
@@ -1433,8 +1433,8 @@ static int test_hash_iteration(uint32_t ext_table)
 	void *next_data;
 	void *data[NUM_ENTRIES];
 	unsigned added_keys;
-	uint32_t iter = 0;
 	int ret = 0;
+	struct rte_hash_iterator_state state;
 
 	ut_params.entries = NUM_ENTRIES;
 	ut_params.name = "test_hash_iteration";
@@ -1463,8 +1463,10 @@ static int test_hash_iteration(uint32_t ext_table)
 		}
 	}
 
+	memset(&state, 0, sizeof(state));
+
 	/* Iterate through the hash table */
-	while (rte_hash_iterate(handle, &next_key, &next_data, &iter) >= 0) {
+	while (rte_hash_iterate(handle, &next_key, &next_data, &state) >= 0) {
 		/* Search for the key in the list of keys added */
 		for (i = 0; i < NUM_ENTRIES; i++) {
 			if (memcmp(next_key, keys[i], ut_params.key_len) == 0) {

--- a/test/test/test_hash_multiwriter.c
+++ b/test/test/test_hash_multiwriter.c
@@ -4,6 +4,7 @@
 
 #include <inttypes.h>
 #include <locale.h>
+#include <string.h>
 
 #include <rte_cycles.h>
 #include <rte_hash.h>
@@ -126,11 +127,14 @@ test_hash_multiwriter(void)
 
 	const void *next_key;
 	void *next_data;
-	uint32_t iter = 0;
 
 	uint32_t duplicated_keys = 0;
 	uint32_t lost_keys = 0;
 	uint32_t count;
+
+	struct rte_hash_iterator_state state;
+
+	memset(&state, 0, sizeof(state));
 
 	snprintf(name, 32, "test%u", calledCount++);
 	hash_params.name = name;
@@ -204,7 +208,7 @@ test_hash_multiwriter(void)
 		goto err3;
 	}
 
-	while (rte_hash_iterate(handle, &next_key, &next_data, &iter) >= 0) {
+	while (rte_hash_iterate(handle, &next_key, &next_data, &state) >= 0) {
 		/* Search for the key in the list of keys added .*/
 		i = *(const uint32_t *)next_key;
 		tbl_multiwriter_test_params.found[i]++;

--- a/test/test/test_hash_readwrite.c
+++ b/test/test/test_hash_readwrite.c
@@ -200,7 +200,6 @@ test_hash_readwrite_functional(int use_ext, int use_htm)
 	unsigned int i;
 	const void *next_key;
 	void *next_data;
-	uint32_t iter = 0;
 
 	uint32_t duplicated_keys = 0;
 	uint32_t lost_keys = 0;
@@ -208,11 +207,15 @@ test_hash_readwrite_functional(int use_ext, int use_htm)
 	int slave_cnt = rte_lcore_count() - 1;
 	uint32_t tot_insert = 0;
 
+	struct rte_hash_iterator_state state;
+
 	rte_atomic64_init(&gcycles);
 	rte_atomic64_clear(&gcycles);
 
 	rte_atomic64_init(&ginsertions);
 	rte_atomic64_clear(&ginsertions);
+
+	memset(&state, 0, sizeof(state));
 
 	if (init_params(use_ext, use_htm, use_jhash) != 0)
 		goto err;
@@ -237,7 +240,7 @@ test_hash_readwrite_functional(int use_ext, int use_htm)
 	rte_eal_mp_wait_lcore();
 
 	while (rte_hash_iterate(tbl_rw_test_param.h, &next_key,
-			&next_data, &iter) >= 0) {
+			&next_data, &state) >= 0) {
 		/* Search for the key in the list of keys added .*/
 		i = *(const uint32_t *)next_key;
 		tbl_rw_test_param.found[i]++;
@@ -361,8 +364,9 @@ test_hash_readwrite_perf(struct perf *perf_results, int use_htm,
 
 	const void *next_key;
 	void *next_data;
-	uint32_t iter = 0;
 	int use_jhash = 0;
+
+	struct rte_hash_iterator_state state;
 
 	uint32_t duplicated_keys = 0;
 	uint32_t lost_keys = 0;
@@ -378,6 +382,8 @@ test_hash_readwrite_perf(struct perf *perf_results, int use_htm,
 	rte_atomic64_clear(&gread_cycles);
 	rte_atomic64_init(&gwrite_cycles);
 	rte_atomic64_clear(&gwrite_cycles);
+
+	memset(&state, 0, sizeof(state));
 
 	if (init_params(0, use_htm, use_jhash) != 0)
 		goto err;
@@ -537,7 +543,7 @@ test_hash_readwrite_perf(struct perf *perf_results, int use_htm,
 		rte_eal_mp_wait_lcore();
 
 		while (rte_hash_iterate(tbl_rw_test_param.h,
-				&next_key, &next_data, &iter) >= 0) {
+				&next_key, &next_data, &state) >= 0) {
 			/* Search for the key in the list of keys added .*/
 			i = *(const uint32_t *)next_key;
 			tbl_rw_test_param.found[i]++;

--- a/test/test/test_hash_readwrite_lf.c
+++ b/test/test/test_hash_readwrite_lf.c
@@ -111,19 +111,22 @@ check_bucket(uint32_t bkt_idx, uint32_t key)
 	uint32_t count = 0;
 	const void *next_key;
 	void *next_data;
+	struct rte_hash_iterator_state state;
 
 	/* Temporary bucket to hold the keys */
 	uint32_t keys_in_bkt[8];
 
 	iter = bkt_idx * 8;
 	prev_iter = iter;
+	rte_hash_iterator_set_iter(tbl_rwc_test_param.h, iter, &state);
 	while (rte_hash_iterate(tbl_rwc_test_param.h,
-			&next_key, &next_data, &iter) >= 0) {
+			&next_key, &next_data, &state) >= 0) {
 
 		/* Check for duplicate entries */
 		if (*(const uint32_t *)next_key == key)
 			return 1;
 
+		iter = rte_hash_iterator_get_iter(&state);
 		/* Identify if there is any free entry in the bucket */
 		diff = iter - prev_iter;
 		if (diff > 1)
@@ -346,13 +349,17 @@ generate_keys(void)
 	const void *next_key;
 	void *next_data;
 	uint32_t count = 0;
+	struct rte_hash_iterator_state state;
 	for (i = 0; i < num_buckets; i++) {
 		/* Check bucket for no keys shifted to alternate locations */
 		if (scanned_bkts[i] == 0) {
 			iter = i * 8;
+			rte_hash_iterator_set_iter(
+				tbl_rwc_test_param.h, iter, &state);
 			while (rte_hash_iterate(tbl_rwc_test_param.h,
-				&next_key, &next_data, &iter) >= 0) {
+				&next_key, &next_data, &state) >= 0) {
 
+				iter = rte_hash_iterator_get_iter(&state);
 				/* Check if key belongs to the current bucket */
 				if (i >= (iter-1)/8)
 					keys_non_shift_path[count++]


### PR DESCRIPTION
This pull request is of the version 5 for the hash table conflict entries iterator, which incorporates Yipeng's and Honnappa's latest patches.