### PR TITLE
lib: add iterator over LPM rules

### DIFF
--- a/lib/librte_lpm/rte_lpm.c
+++ b/lib/librte_lpm/rte_lpm.c
@@ -85,6 +85,63 @@ depth_to_range(uint8_t depth)
 	return 1 << (RTE_LPM_MAX_DEPTH - depth);
 }
 
+int __rte_experimental
+rte_lpm_iterator_state_init(const struct rte_lpm *lpm, uint32_t ip,
+	uint8_t depth, struct rte_lpm_iterator_state *state)
+{
+	if (lpm == NULL || depth > RTE_LPM_MAX_DEPTH || state == NULL)
+		return -EINVAL;
+
+	state->dmask = depth == 0 ? 0 : depth_to_mask(depth);
+	state->ip_masked = ip & state->dmask;
+	state->depth = depth == 0 ? 1 : depth;
+	state->next = 0;
+	state->lpm = lpm;
+
+	return 0;
+}
+
+/*
+ * An iterator over its rule entries.
+ */
+int __rte_experimental
+rte_lpm_rule_iterate(struct rte_lpm_iterator_state *state,
+	const struct rte_lpm_rule **rule)
+{
+	if (state == NULL || rule == NULL) {
+		if (rule != NULL)
+			*rule = NULL;
+
+		return -EINVAL;
+	}
+
+	while (state->depth <= RTE_LPM_MAX_DEPTH) {
+		uint32_t rule_gindex =
+			state->lpm->rule_info[state->depth - 1].first_rule;
+		uint32_t last_rule = rule_gindex +
+			state->lpm->rule_info[state->depth - 1].used_rules;
+		uint32_t rule_index = rule_gindex + state->next;
+
+		while (rule_index < last_rule) {
+			if ((state->lpm->rules_tbl[rule_index].ip &
+					state->dmask) == state->ip_masked) {
+				state->next = rule_index - rule_gindex + 1;
+				*rule = (const struct rte_lpm_rule *)
+					&state->lpm->rules_tbl[rule_index];
+				return 0;
+			}
+
+			rule_index++;
+		}
+
+		state->depth++;
+		state->next = 0;
+	}
+
+	*rule = NULL;
+	return -ENOENT;
+}
+
 /*
  * Find an existing lpm table and return a pointer to it.
  */

--- a/lib/librte_lpm/rte_lpm.h
+++ b/lib/librte_lpm/rte_lpm.h
@@ -188,6 +188,61 @@ struct rte_lpm {
 	struct rte_lpm_rule *rules_tbl; /**< LPM rules. */
 };
 
+/** LPM iterator state structure. */
+struct rte_lpm_iterator_state {
+	uint32_t dmask;
+	uint32_t ip_masked;
+	uint8_t  depth;
+	uint32_t next;
+	const struct rte_lpm *lpm;
+};
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * Initialize the lpm iterator state.
+ *
+ * @param lpm
+ *   LPM object handle
+ * @param ip
+ *   IP of the rule to be searched
+ * @param depth
+ *   Initial depth of the rule to be searched.
+ *   Pass zero to enumerate the whole LPM table.
+ * @param state
+ *   Pointer to the iterator state
+ * @return
+ *   0 on successfully initialize the state variable, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ */
+int __rte_experimental
+rte_lpm_iterator_state_init(const struct rte_lpm *lpm, uint32_t ip,
+	uint8_t depth, struct rte_lpm_iterator_state *state);
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * An iterator over its rule entries.
+ * The iterator should require a prefix as a parameter
+ * and should list all entries as long as the given prefix (or longer).
+ *
+ * @param state
+ *   Pointer to the LPM rule iterator state
+ * @param rule
+ *   Pointer to the next rule entry
+ * @return
+ *   0 on successfully searching the next rule entry, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ *   - ENOENT - no rule entries found
+ */
+int __rte_experimental
+rte_lpm_rule_iterate(struct rte_lpm_iterator_state *state,
+	const struct rte_lpm_rule **rule);
+
 /**
  * Create an LPM object.
  *

--- a/lib/librte_lpm/rte_lpm6.c
+++ b/lib/librte_lpm/rte_lpm6.c
@@ -69,13 +69,6 @@ struct rte_lpm6_tbl_entry {
 	uint32_t ext_entry :1;   /**< External entry. */
 };
 
-/** Rules tbl entry structure. */
-struct rte_lpm6_rule {
-	uint8_t ip[RTE_LPM6_IPV6_ADDR_SIZE]; /**< Rule IP address. */
-	uint32_t next_hop; /**< Rule next hop. */
-	uint8_t depth; /**< Rule depth. */
-};
-
 /** Rules tbl entry key. */
 struct rte_lpm6_rule_key {
 	uint8_t ip[RTE_LPM6_IPV6_ADDR_SIZE]; /**< Rule IP address. */
@@ -237,6 +230,65 @@ rebuild_lpm(struct rte_lpm6 *lpm)
 			(void **) &next_hop, &iter) >= 0)
 		rte_lpm6_add(lpm, rule_key->ip, rule_key->depth,
 			(uint32_t) next_hop);
+}
+
+int __rte_experimental
+rte_lpm6_iterator_state_init(const struct rte_lpm6 *lpm, uint8_t *ip,
+	uint8_t depth, struct rte_lpm6_iterator_state *state)
+{
+	if (lpm == NULL || depth > RTE_LPM6_MAX_DEPTH || state == NULL)
+		return -EINVAL;
+
+	if (ip == NULL)
+		memset(state->ip_masked, 0, sizeof(state->ip_masked));
+	else {
+		ip6_copy_addr(state->ip_masked, ip);
+		ip6_mask_addr(state->ip_masked, depth);
+	}
+
+	state->depth = depth;
+	state->next = 0;
+	state->lpm = lpm;
+
+	return 0;
+}
+
+/*
+ * An iterator over its rule entries.
+ */
+int __rte_experimental
+rte_lpm6_rule_iterate(struct rte_lpm6_iterator_state *state,
+	struct rte_lpm6_rule *rule)
+{
+	uint64_t next_hop;
+	struct rte_lpm6_rule_key *rule_key;
+
+	/* Check user arguments. */
+	if (state == NULL || rule == NULL)
+		return -EINVAL;
+
+	/* Scan rules hash table to find matched rules. */
+	while (rte_hash_iterate(state->lpm->rules_tbl, (void *) &rule_key,
+			(void **) &next_hop, &state->next) >= 0) {
+		uint8_t rule_ip_masked[RTE_LPM6_IPV6_ADDR_SIZE];
+
+		if (rule_key->depth < state->depth)
+			continue;
+
+		ip6_copy_addr(rule_ip_masked, rule_key->ip);
+		ip6_mask_addr(rule_ip_masked, state->depth);
+
+		/* If rule is found return the rule index. */
+		if ((memcmp(state->ip_masked, rule_ip_masked,
+				RTE_LPM6_IPV6_ADDR_SIZE) == 0)) {
+			rule->depth = rule_key->depth;
+			ip6_copy_addr(rule->ip, rule_key->ip);
+			rule->next_hop = next_hop;
+			return 0;
+		}
+	}
+
+	return -ENOENT;
 }
 
 /*

--- a/lib/librte_lpm/rte_lpm6.h
+++ b/lib/librte_lpm/rte_lpm6.h
@@ -22,6 +22,13 @@ extern "C" {
 /** Max number of characters in LPM name. */
 #define RTE_LPM6_NAMESIZE                 32
 
+/** Rules tbl entry structure. */
+struct rte_lpm6_rule {
+	uint8_t ip[RTE_LPM6_IPV6_ADDR_SIZE]; /**< Rule IP address. */
+	uint32_t next_hop; /**< Rule next hop. */
+	uint8_t depth; /**< Rule depth. */
+};
+
 /** LPM structure. */
 struct rte_lpm6;
 
@@ -31,6 +38,61 @@ struct rte_lpm6_config {
 	uint32_t number_tbl8s;   /**< Number of tbl8s to allocate. */
 	int flags;               /**< This field is currently unused. */
 };
+
+/** LPM6 iterator state structure. */
+struct rte_lpm6_iterator_state {
+	uint8_t  ip_masked[RTE_LPM6_IPV6_ADDR_SIZE];
+	uint8_t  depth;
+	uint32_t next;
+	const struct rte_lpm6 *lpm;
+};
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * Initialize the lpm iterator state.
+ *
+ * @param lpm
+ *   LPM object handle
+ * @param ip
+ *   IP of the rule to be searched
+ *   ip == NULL behaves as having passed an all-zero IPv6 address
+ * @param depth
+ *   Initial depth of the rule to be searched.
+ *   Pass zero to enumerate the whole LPM table.
+ * @param state
+ *   Pointer to the iterator state
+ * @return
+ *   0 on successfully initialize the state variable, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ */
+int __rte_experimental
+rte_lpm6_iterator_state_init(const struct rte_lpm6 *lpm, uint8_t *ip,
+	uint8_t depth, struct rte_lpm6_iterator_state *state);
+
+/**
+ * @warning
+ * @b EXPERIMENTAL: this API may change without prior notice.
+ *
+ * An iterator over its rule entries.
+ * The iterator should require a prefix as a parameter
+ * and should list all entries as long as the given prefix (or longer).
+ *
+ * @param state
+ *   Pointer to the LPM rule iterator state
+ * @param rule
+ *   Pointer to the rule entry
+ * @return
+ *   0 on successfully searching the next rule entry, negative otherwise.
+ *   Possible error values include:
+ *   - EINVAL - invalid parameter passed to function
+ *   - ENOENT - no rule entries found
+ */
+int __rte_experimental
+rte_lpm6_rule_iterate(struct rte_lpm6_iterator_state *state,
+	struct rte_lpm6_rule *rule);
 
 /**
  * Create an LPM object.

--- a/lib/librte_lpm/rte_lpm_version.map
+++ b/lib/librte_lpm/rte_lpm_version.map
@@ -44,3 +44,13 @@ DPDK_17.05 {
 	rte_lpm6_lookup_bulk_func;
 
 } DPDK_16.04;
+
+EXPERIMENTAL {
+	global:
+
+	rte_lpm_iterator_state_init;
+	rte_lpm_rule_iterate;
+	rte_lpm6_iterator_state_init;
+	rte_lpm6_rule_iterate;
+
+};


### PR DESCRIPTION
Add an iterator over the LPM rules.
The iterator requires a prefix as a parameter and
lists all entries as long as the given prefix (or longer).

Signed-off-by: Qiaobin Fu <qiaobinf@bu.edu>
Reviewed-by: Cody Doucette <doucette@bu.edu>
Reviewed-by: Michel Machado <michel@digirati.com.br>