### PR TITLE
lpm: add functions for prefetching LPM table entries

### DIFF
--- a/lib/librte_lpm/rte_lpm_version.map
+++ b/lib/librte_lpm/rte_lpm_version.map
@@ -44,3 +44,15 @@ DPDK_17.05 {
 	rte_lpm6_lookup_bulk_func;
 
 } DPDK_16.04;
+
+EXPERIMENTAL {
+	global:
+
+	rte_lpm_prefetch_tbl24_entry;
+	rte_lpm_prefetch_tbl8_entry;
+	rte_lpm_prefetch_tbl24_entry_non_temporal;
+	rte_lpm_prefetch_tbl8_entry_non_temporal;
+	rte_lpm_lookup_step1;
+	rte_lpm_lookup_step2;
+
+};


### PR DESCRIPTION
This patch allows to prefetch LPM table entries for both tbl24
and tbl8 tables. To do a single LPM lookup with memory prefetches,
one needs to first call rte_lpm_prefetch_tbl24_entry()/
rte_lpm_prefetch_tbl24_entry_non_temporal() to prefetch the tbl24
entry, and then call rte_lpm_lookup_step1() to decide the next step:
(1) error happens and terminates; (2) obtains the next hop info and
terminates; (3) needs to process the LPM table lookup further by calling
rte_lpm_prefetch_tbl8_entry()/rte_lpm_prefetch_tbl8_entry_non_temporal()
to prefetch the tbl8 entry and finally calling rte_lpm_lookup_step2() to
get the next hop info.

An example of a single IP lookup process:

```
......

unsigned tbl8_index;
uint32_t next_hop;

rte_lpm_prefetch_tbl24_entry(lpm, ip);
ret = rte_lpm_lookup_step1(lpm, &tbl8_index, ip, &next_hop);
if (ret < 0) /* Error happens. */
	return ret;
else if (ret == 0) /* Find next_hop info. */
	return next_hop;

/* Needs further process. */
rte_lpm_prefetch_tbl8_entry(lpm, tbl8_index);
ret = rte_lpm_lookup_step2(lpm, tbl8_index, &next_hop);
if (ret < 0) /* Error happens. */
	return ret;
else /* Find next_hop info. */
	return next_hop;

......
```